### PR TITLE
don't exclude .c files as they are needed by the includes

### DIFF
--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -43,7 +43,6 @@ if not exist %XERCESSOLUTION% (
 
 REM Headers. Must be a better way...
 echo .cpp > excludelist.txt
-echo .c >> excludelist.txt
 mkdir %LIBRARY_INC%\xercesc
 xcopy /s /exclude:excludelist.txt src\xercesc %LIBRARY_INC%\xercesc
 if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 21bb097b711a513275379b59757cba4c
 
 build:
-    number: 1
+    number: 2
     features:
         - vc9  # [win and py27]
         - vc10  # [win and py34]


### PR DESCRIPTION
It turns out that .c files are needed by the includes. This re-instates them so they match `defaults`.